### PR TITLE
在获取包信息的时候，检查一下 main 文件是否存在

### DIFF
--- a/lib/util/get-manifest.js
+++ b/lib/util/get-manifest.js
@@ -62,6 +62,7 @@ function getPackageDeclare(dir) {
     // }
     // 因此这里把main后缀的.js给去掉
     var main = (pkgData.main || 'main').replace(/\.js$/, '');
+    checkMainExists(dir, main, pkgName);
     var pkg = {
         name: pkgName,
         version: pkgVersion
@@ -71,6 +72,20 @@ function getPackageDeclare(dir) {
     }
 
     return pkg;
+
+    /**
+     * 检查 main 是否真的存在
+     *
+     * @param {string} dir      package 的目录地址
+     * @param {string} main     主文件
+     * @param {string} pkgName  package 名字
+     */
+    function checkMainExists(dir, main, pkgName) {
+        var mainFile = path.join(dir, 'src', main + '.js');
+        if (!fs.existsSync(mainFile)) {
+            throw new Error('the main file of package `' + pkgName + '` is not exists: ' + mainFile);
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
主要是为了在项目构建的时候就检测出此包是否有可能会导致将来的 404 错误，将可能的错误扼杀在摇篮中。